### PR TITLE
fix: add missing comma in 4-failures-packed

### DIFF
--- a/python_hydra_parser/src/hydra_parser/__init__.py
+++ b/python_hydra_parser/src/hydra_parser/__init__.py
@@ -79,7 +79,7 @@ def main():
         write_csv(f"3-failures-{system}", "id,name",
             ((all_jobs[ji].id, all_jobs[ji].name) for ji in jobs))
 
-    write_csv(f"4-failures-packed", "id,name" + ','.join(SUPPORTED_SYSTEMS),
+    write_csv(f"4-failures-packed", "name," + ','.join(SUPPORTED_SYSTEMS),
         ((pkg, *failures.values()) for pkg, failures in packed.items()))
 
 


### PR DESCRIPTION
Currently, results/4-failures-packed.csv contains the following header: `id,namex86_64-linux,aarch64-linux,x86_64-darwin,aarch64-darwin`

Added the missing comma :)