### PR TITLE
feat: also run on staging-next

### DIFF
--- a/.github/workflows/periodic-run.yaml
+++ b/.github/workflows/periodic-run.yaml
@@ -42,6 +42,10 @@ jobs:
           git fetch origin
           git checkout results
 
+      - name: Rebase if needed
+        run: |
+          git pull --rebase origin main
+
       - name: Back prev results
         run: |
           for branch in trunk staging-next; do

--- a/.github/workflows/periodic-run.yaml
+++ b/.github/workflows/periodic-run.yaml
@@ -52,13 +52,10 @@ jobs:
         run: |
           nix run github:${{ github.repository }}
 
-      # Note: this script does not work properly, and create duplicates issues
-      # which gets way too annoying.
-
-      # - name: Open issue for new build failures
-      #  run: |
-      #    GH_REPOSITORY=${{ github.repository }} \
-      #      GH_TOKEN=${{ secrets.GITHUB_TOKEN }} python create-issues.py
+      - name: Open issue for new build failures
+        run: |
+         GH_REPOSITORY=${{ github.repository }} \
+           GH_TOKEN=${{ secrets.GITHUB_TOKEN }} python create-issues.py
 
       - name: Cleanup
         run: |

--- a/.github/workflows/periodic-run.yaml
+++ b/.github/workflows/periodic-run.yaml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Back prev results
         run: |
-          mv results/concerned-failures.json previous.json
+          for branch in trunk staging-next; do
+            mv results/$branch/concerned-failures.json previous-$branch.json || echo [] > previous-$branch.json
+          done
 
       - name: Run collect script
         run: |
@@ -60,7 +62,7 @@ jobs:
 
       - name: Cleanup
         run: |
-          rm ./previous.json
+          rm previous-*.json
 
       - name: Commit results
         run: |

--- a/collect-multiple.sh
+++ b/collect-multiple.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+for NIXPKGS_BRANCH in trunk staging-next; do
+    export NIXPKGS_BRANCH
+    if type -a collect.sh; then
+        collect.sh
+    else
+        ./collect.sh
+    fi
+done

--- a/collect.sh
+++ b/collect.sh
@@ -3,13 +3,15 @@
 
 set -euo pipefail
 
-[[ ! -s result.html ]] && \
+export NIXPKGS_BRANCH="${NIXPKGS_BRANCH:-trunk}"
+
+[[ ! -s result.html ]] &&
   curl -L \
    -A "nixpkgs-failure-notify (reach sigmanificient)" \
    -o result.html \
-   https://hydra.nixos.org/jobset/nixpkgs/trunk/latest-eval?full=1
+   "https://hydra.nixos.org/jobset/nixpkgs/${NIXPKGS_BRANCH}/latest-eval?full=1"
 
-mkdir -p results
+mkdir -p "results/${NIXPKGS_BRANCH}"
 grep -Po "Evaluation (\d+) of jobset" result.html \
   | cut -f 2 -d ' ' \
   | head -n 1 >> results/job_id
@@ -31,4 +33,10 @@ else
 fi
 
 $fhp_cmd result.html | $hydra_to_cvs_cmd
-./filter-maintained-packages.nix > results/concerned-failures.json
+
+# --argstr doesn't work for some reason
+nix eval --json --impure --expr "
+  import ./filter-maintained-packages.nix {
+    branch = \"${NIXPKGS_BRANCH}\";
+  }" > "results/${NIXPKGS_BRANCH}/concerned-failures.json"
+rm result.html

--- a/create-issues.py
+++ b/create-issues.py
@@ -28,9 +28,11 @@ def create_issues(branch="trunk"):
     assert gh_token is not None
 
 
+    print("Pocessing", len(rows), "items")
     for row in rows:
         pkg = row[0]
         if pkg in known_fails:
+            print("Skipping", pkg, "(known)")
             continue
 
         failures = [

--- a/create-issues.py
+++ b/create-issues.py
@@ -1,56 +1,65 @@
 #!/usr/bin/env python3
 
+from pathlib import PurePath
+
+import glob
 import json
 import subprocess
 import os
 
-with open("results/concerned-failures.json") as f:
-    rows = json.load(f)
+def create_issues(branch="trunk"):
+    with open(f"results/{branch}/concerned-failures.json") as f:
+        rows = json.load(f)
 
-with open("previous.json") as f:
-    known_fails = [r[0] for r in json.load(f)]
-
-
-SUPPORTED_SYSTEMS = tuple(
-    f"{arch}-{sys}"
-    for sys in ("linux", "darwin")
-    for arch in ("x86_64", "aarch64")
-)
-
-repo = os.getenv("GH_REPOSITORY")
-assert repo is not None
-
-gh_token = os.getenv("GH_TOKEN")
-assert gh_token is not None
+    with open(f"previous-{branch}.json") as f:
+        known_fails = [r[0] for r in json.load(f)]
 
 
-for row in rows:
-    pkg = row[0]
-    if pkg in known_fails:
-        continue
-
-    failures = [
-        f"- [ ] `{plat}`: [log](https://hydra.nixos.org/build/{build_id}/log)"
-        for plat, build_id in zip(SUPPORTED_SYSTEMS, row[1:])
-        if build_id
-    ]
-
-    if not failures:
-        continue
-
-    body = (
-        "@Sigmanificient\n\n"
-        + f"Build failures for `{pkg}`:\n\n"
-        + "\n".join(failures)
+    SUPPORTED_SYSTEMS = tuple(
+        f"{arch}-{sys}"
+        for sys in ("linux", "darwin")
+        for arch in ("x86_64", "aarch64")
     )
 
-    title = f"{pkg} build failures"
+    repo = os.getenv("GH_REPOSITORY")
+    assert repo is not None
 
-    print(f"Creating issue: {title}")
-    subprocess.run([
-        "gh", "issue", "create",
-        "--repo", repo,
-        "--title", title,
-        "--body", body
-        ], check=True, env={"GITHUB_TOKEN": gh_token}
-    )
+    gh_token = os.getenv("GH_TOKEN")
+    assert gh_token is not None
+
+
+    for row in rows:
+        pkg = row[0]
+        if pkg in known_fails:
+            continue
+
+        failures = [
+            f"- [ ] `{plat}`: [log](https://hydra.nixos.org/build/{build_id}/log)"
+            for plat, build_id in zip(SUPPORTED_SYSTEMS, row[1:])
+            if build_id
+        ]
+
+        if not failures:
+            continue
+
+        body = (
+            "@Sigmanificient\n\n"
+            + f"Build failures for `{pkg}`:\n\n"
+            + "\n".join(failures)
+        )
+
+        title = f"[{branch}] {pkg} build failures"
+
+        print(f"Creating issue: {title}")
+        subprocess.run([
+            "gh", "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body,
+            ], check=True, env={"GITHUB_TOKEN": gh_token}
+        )
+
+if __name__ == "__main__":
+    for failure_path in glob.glob("results/*/concerned-failures.json"):
+        branch = PurePath(failure_path).parts[-2]
+        create_issues(branch=branch)

--- a/filter-maintained-packages.nix
+++ b/filter-maintained-packages.nix
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S nix eval --json -f
+{
+  branch ? "trunk",
+}:
 let
   nixpkgs = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/master.tar.gz";
@@ -6,7 +8,7 @@ let
 
   pkgs = import nixpkgs { };
 
-  failures-packed = pkgs.lib.pipe ./results/4-failures-packed.csv [
+  failures-packed = pkgs.lib.pipe ./results/${branch}/4-failures-packed.csv [
     builtins.readFile
     (pkgs.lib.strings.splitString "\n")
     builtins.tail

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,10 @@
       inherit (pkgs) lib;
     in {
       default = pkgs.symlinkJoin {
-         name = "collect-full";
+         name = "collect-multiple-full";
          paths = with self.packages.${pkgs.system}; [
           collect
+          collect-multiple
           fast-hydra-parser
           hydra-parser
           create-issues
@@ -79,6 +80,12 @@
           self.packages.${system}.fast-hydra-parser
           self.packages.${system}.hydra-parser
         ];
+      };
+
+      collect-multiple = pkgs.writeShellApplication {
+        name = "collect-multiple.sh";
+        text = builtins.readFile ./collect-multiple.sh;
+        runtimeInputs = [ self.packages.${pkgs.system}.collect ];
       };
 
       fast-hydra-parser = pkgs.callPackage (

--- a/python_hydra_parser/src/hydra_parser/__init__.py
+++ b/python_hydra_parser/src/hydra_parser/__init__.py
@@ -41,9 +41,10 @@ class Job:
         )
 
 
+branch = os.getenv("NIXPKGS_BRANCH") or "trunk"
 
 def write_csv(name: str, header: str, lines):
-    with open(f"results/{name}.csv", "w+") as f:
+    with open(f"results/{branch}/{name}.csv", "w+") as f:
         f.write(header + "\n")
         for line in lines:
             f.write(','.join(line) + '\n')


### PR DESCRIPTION
refactors everything so it works with multiple `results/<branch>`, directories, then creates `collect-multiple.sh` to do so for both `trunk` and `staging-next`

I wrote this for myself but I figured you might enjoy this as well :) I think it's nice to know in advance during `staging-next` cycles whether your package will become broken by it. Should also help with ZHF! :)

It's a bit quick and dirty, but it seems to do the job.